### PR TITLE
Updated Bahrain SOP [INFO+DEL+GND+TWR]

### DIFF
--- a/docs/sops/OBBI - Bahrain International Airport/1. GeneralInformation.md
+++ b/docs/sops/OBBI - Bahrain International Airport/1. GeneralInformation.md
@@ -74,8 +74,9 @@ Bahrain International Airport (OBBI) is a fully controlled airport.
 |  **Radio Callsign** | **Logon Callsign** | **Abbreviation** | **Frequency (MHz)** |
 |:-------------------:|:------------------:|:----------------:|:-------------------:|
 | Bahrain Information |      OBBI_ATIS     |       ATIS       |       127.200       |
-|   Bahrain Delivery  |      OBBI_DEL      |        DLV       |       121.900       |
-|    Bahrain Ground   |      OBBI_GND      |        SMC       |       121.850       |
+|   Bahrain Delivery  |      OBBI_DEL      |        GMP       |       121.900       |
+|    Bahrain Ground   |      OBBI_GND      |        GMC       |       121.850       |
 |    Bahrain Tower    |      OBBI_TWR      |        TWR       |       118.500       |
 |   Bahrain Approach  |      OBBI_APP      |        APP       |       127.850       |
+|   Bahrain Director  |      OBBI_F_APP      |        APP       |       119.100       |
 |    Bahrain Radar    |     OBBB_1_CTR     |        CTR       |       127.525       |

--- a/docs/sops/OBBI - Bahrain International Airport/2. Delivery.md
+++ b/docs/sops/OBBI - Bahrain International Airport/2. Delivery.md
@@ -5,16 +5,16 @@ slug: OBBIDEL
 The section outlines the Standard Operating Procedures for Delivery Operations at Bahrain International Airport (OBBI)
 
 ## 2.1 General Provisions
-Bahrain Clearance **(OBBI_DEL)** or Delivery Clearance **(DLV)** is responsible for validating flight plans and issuing IFR/VFR clearances to departing aircraft. This includes thoroughly reviewing the filed route, assigned altitude, and departure procedure to ensure accuracy. If any discrepancies, errors, or invalid information are detected, the controller must correct them before issuing the final clearance.
+
+Bahrain Clearance Delivery **(OBBI_DEL)** or 'GMP' is responsible for validating flight plans and issuing IFR/VFR clearances to departing aircraft. This includes thoroughly reviewing the filed route, assigned altitude, and departure procedure to ensure accuracy. If any discrepancies, errors, or invalid information are detected, the controller must correct them before issuing the final clearance.
 
 In addition to route validation, the Delivery Controller plays a key role in managing taxiway operations. To reduce delays and congestion during periods of high departure activity, proactive measures such as holding aircraft at the gate may be implemented to conserve fuel and optimize the flow of outbound traffic on the taxiways.
 
 ---
 
 ## 2.2 Departure Clearance
-
 ### 2.2.1 General
-DLV is responsible for issuing clearance for departing aircraft. Pilots may be expected to report the following information on first contact:
+Delivery is responsible for issuing clearance for departing aircraft. Pilots may be expected to report the following information on first contact:
 - Callsign
 - Aircraft Type
 - Parking Stand
@@ -24,68 +24,66 @@ DLV is responsible for issuing clearance for departing aircraft. Pilots may be e
 ### 2.2.2 Information contained in a departure clearance
 An IFR clearance shall be in the following format:
 - Callsign
-- Airway and Bahrain FIR exit point
+- Airway and a waypoint
+- Heading after departure
 - Initially cleared altitude
 - Assigned SSR code
 
 ### 2.2.3 Phraseology
+
 ::::info Note
-"A GulfAir flight to Dubai International Airport will be used as an example going forward for the phraseology."
+A Gulf Air flight to Dubai International Airport will be used as an example for this phraseology.
 ::::
 
 **Pilot:**
-> "Bahrain Delivery, Good Evening, GFA512, Type B789, Stand 18, Request IFR Clearance to Dubai International as filed."
+>"Bahrain Delivery, Good Evening, GFA512, Type B789, Stand 18, Request IFR Clearance to Dubai International as filed."
 
 **Controller:**
-> "GFA512, Bahrain Delivery, Good Evening. Cleared to Dubai, via N697 SODAK, Expect Radar vectors after Departure Runway 30R, Maintain Altitude 4000ft, Squawk 4411"
+>"GFA512, Bahrain Delivery, Good Evening. Cleared to Dubai, via **N697 SODAK**, after departure fly **heading 345°**, maintain altitude **4000ft**, squawk **4411**."
 
 ::::caution Remember
-"DLV shall obtain a full readback of the clearance. If the pilot does not report the current ATIS letter on first contact, DLV shall pass the current ATIS letter."
+The heading flown after departure will be assigned following the procedures outlined in Section 4.3.3.
 ::::
 
 **Pilot:**
-> "Cleared to Dubai, via N697 SODAK, Expect Radar vectors after Departure Runway 30R, Maintain Altitude 4000ft, Squawk 4411, GFA512"
+>"Cleared to Dubai, via N697 SODAK, after departure heading 345°, maintain altitude 4000ft, squawk 4411, GFA512."
 
 **Controller:**
-> "GFA512, Readback Correct, Information Alpha, Report ready for Pushback and Startup"
+>"GFA512, readback correct, information alpha, contact Bahrain Ground 121.850 for push and start."
 
 **Pilot:**
-> "Information A, Will Report ready for Pushback and Startup, GFA512"
+>"Information A, Ground 121.850, GFA512."
 
 ::::caution Remember
-Departing aircraft must remain on the delivery frequency and report when ready for pushback before being handed off to the Surface Movement Controller (SMC). This allows aircraft to be held at the gate, following the procedures outlined in Section 2.6.
+Delivery shall obtain a full readback of the clearance. If the pilot does not report the current ATIS letter on first contact, Delivery shall pass the current ATIS letter.
 ::::
-
-**Pilot:**
-> “Ready for Pushback, GFA512”
-
-**Controller:**
-> “GFA512, HOLD Position, Contact Ground 121.850.”
-
-**Pilot:**
-> “WILCO Ground 121.850, GFA512”
 
 ---
 
 ### 2.3 Datalink Clearance
+
 Clearance for aircraft may also be provided via DCL, which helps reduce controller workload and frequency congestion. For aircraft equipped with the necessary systems, this will be delivered through the onboard ACARS system. Controllers must ensure that DCL is available for use at all times.
 
 ---
 
 ### 2.4 Aircraft requiring a reroute
+
 Aircraft requiring a reroute shall not be given PDC/DCL. Instead, a voice clearance must be used. This shall be communicated to the pilot appropriately.
 
 ---
 
 ### 2.5 Departure Procedures
-Bahrain International does not have any published SIDs. Instead, TWR will assign an initial heading to departing aircraft and APP will provide radar vectors enroute afterwards. Therefore, DLV will only inform the pilot in the clearance that radar vectors will be provided after departure.
 
-The initial climb is 3000ft for propeller aircraft and helicopters and 4000ft for jet aircraft.
+Bahrain International does not have any published SIDs. Instead, Delivery will assign an initial heading to departing aircraft.
+
+The initial climb is **3000ft** for propeller aircraft and helicopters and **4000ft** for jet aircraft.
 
 ---
 
 ### 2.6 Requested cruising level
+
 Aircraft routes out of the aerodrome must comply with all routing and level restrictions. This is based on direction and type of flight.
+
 | **Destination** | **Restriction** |
 |:---------------:|:---------------:|
 |       OM**      |    FL 250   |
@@ -100,7 +98,7 @@ Aircraft routes out of the aerodrome must comply with all routing and level rest
 ### 2.7.1 Calculated Take-Off time (CTOT)
 
 During periods of high intensity departure activity, aircraft shall be assigned a Calculated Take-Off Time (CTOT), either automatically or manually. The CTOT is always a minimum of 30 minutes from the present time.
-Using CTOT, DLV shall plan the departure sequence that maximises runway utilisation and results in the least average departure delay while considering direction of flight, wake turbulence category of aircraft and any other relevant consideration.
+Using CTOT, Delivery shall plan the departure sequence that maximises runway utilisation and results in the least average departure delay while considering direction of flight, wake turbulence category of aircraft and any other relevant consideration.
 
 ### 2.7.2 Target off-block time (TOBT)
 
@@ -110,4 +108,4 @@ aircraft stand in relation to the runway, it might be shorter or longer. Aircraf
 their TOBT should be instructed to hold position and they should be told the sequence to expect.
 
 **Example:**
->”FDB53, HOLD POSITION. NUMBER 3 FOR STARTUP, EXPECT PUSHBACK AT TIME 45”
+>"FDB53, Hold position. Number 3 for startup, expect pushback at time 14:20z."

--- a/docs/sops/OBBI - Bahrain International Airport/3. Ground.md
+++ b/docs/sops/OBBI - Bahrain International Airport/3. Ground.md
@@ -8,7 +8,7 @@ The section outlines the Standard Operating Procedures for Ground Operations at 
 
 ## 3.1 General Provisions
 
-The Surface Movement Controller (SMC) is responsible for managing aircraft movements on all aerodrome movement areas except runways and their associated taxiways. Departing aircraft are given pushback instructions and instructions to taxi to the runway holding points. Arriving aircraft are assigned a stand and instructed to taxi as appropriate.
+The Ground Movement Controller (OBBI_GND) or 'GMC' is responsible for managing aircraft movements on all aerodrome movement areas except runways and their associated taxiways. Departing aircraft are given pushback instructions and instructions to taxi to the runway holding points. Arriving aircraft are assigned a stand and instructed to taxi as appropriate.
 
 ::::danger Important
 Runway 12R/30L is always used as a taxiway. It will be referred to as taxiway A in this case.
@@ -18,93 +18,110 @@ Runway 12R/30L is always used as a taxiway. It will be referred to as taxiway A 
 
 ## 3.2 Departure pushback procedure
 ### 3.2.1 General pushback procedure
-When aircraft have been handed off from DLV, they shall be fully ready for pushback and have reached their TOBT. Assuming no obstructions, they shall be instructed to push back immediately.
+When aircraft have been handed off from GMP, they shall be fully ready for pushback and have reached their TOBT. Assuming no obstructions, they shall be instructed to push back immediately.
 
 Aircraft requesting push that are not squawking their assigned transponder code shall be instructed to hold position and squack the correct code. They must not be allowed to move until doing so.
 
 Pushback direction is based primarily on aircraft location and runway configuration. Pushbacks shall face the runway threshold that is in use for departures.
 
 **Example:**
+
 **Pilot:**
-> "Bahrain Ground, Good Evening, GFA512, Stand 18, Requesting Pushback"
+>"Bahrain Ground, good evening, GFA512, stand 18, requesting push and start."
 
 **Controller:**
-> "GFA512, Bahrain Ground, Good Evening. Pusback Approved, Face West"
+>"GFA512, Bahrain Ground, pusback and startup approved, face west, QNH 1020."
 
 ::::caution Remember
 Conditional pushback instructions may also be issued if an aircraft is taxing behind another waiting for pushback. The clerance should begin and end with the word "BEHIND".
 ::::
 
 **Pilot:**
-> "Bahrain Ground, FDB3EF, Requesting Pushback"
+>"Bahrain Ground, FDB3EF, requesting push and start."
 
 **Controller:**
-> "FDB3EF, BEHIND GULF AIR B789 Passing Right to Left, Pushback approved, Face West BEHIND"
+>"FDB3EF, **BEHIND** the Gulf Air B789 passing right to left, pushback approved, face west **BEHIND**, QNH 1020."
+
+::::note Remember
+QNH is relayed when pushback clearance is issued.
+::::
 
 ### 3.2.2 Pushback Types
 #### Standard Pushback
-This type will normally have the aircraft stop abeam the adjacent stand. the phraseology for this type of pushback is laid down in 3.2.1
+This type will normally have the aircraft stop abeam the adjacent stand. the phraseology for this type of pushback is provided in Section 3.2.1
 
 
 #### Short Pushback
 A short pushback instruction shall require the aircraft to complete the pushback procedure abeam the current stand such that the adjacent stand will not be blocked.
 
 **Example:**
->"OMA51, Short Pushback approved, Face West to finish abeam Stand 9."
+>"OMA51, short pushback approved, face west to finish abeam Stand 9. QNH 1020"
 
 #### Long Pushback
 A long pushback instruction shall require the aircraft to complete the pushback procedure two stands away from where the pushback was commenced. This maneuver may be used when aircraft are vacating a stand to be used by another aircraft taxing in.
 
 **Example:**
->"UAE51W, Long Pushback approved, Face West to finish abeam Stand 12."
+>"UAE51W, long pushback approved, face west to finish abeam Stand 12. QNH 1020."
 #### Simultaneous Pushback Operations
-Simultaneous pushbacks may be permitted from adjacent stands provided aircraft are instructed to maneuver in accordance with 3.2.2 such that on completion of both aircrafts' pushback operation, they will be separated on the taxiway by two aircraft stands.
+Simultaneous pushbacks may be permitted from adjacent stands provided aircraft are instructed to maneuver in accordance with Section 3.2.2 such that on completion of both aircrafts' pushback operation, they will be separated on the taxiway by two aircraft stands.
 
 ---
 
 ## 3.3 Departure Taxi procedure
+
 Where aircraft are taxied to runway holding points, transfer of control to TWR shall be made early enough such that the aircraft is not required to stop its taxi.
 
 As there are no published intermediate holding points in Bahrain, aircraft may be instructed to hold short of an intersection taxiway instead.
 
 **Example:**
->"GFA512, Taxi via A, Hold Short A5, QNH 1020"
-
-::::caution
-QNH is relayed to the aircraft on the Taxi instruction
-::::
+>"GFA512, taxi via A, hold short A5."
 
 ### 3.3.1 30R Configuration
 
-Taxi to the runway shall be conducted on taxiway A to depart aircraft full length. If requested and traffic permitting intersection departures can be used. Caution should be exercised with aircraft taxiing out from the western apron or the Executive/Cargo Apron when there is a simultaneous arrival to these aprons as there is only one taxiway available.
+Taxi out to the runway shall be conducted on taxiway A to depart aircraft full length. If requested and traffic permitting intersection departures can be used.
+
+::::caution Remember
+Caution should be exercised with aircraft taxiing out from the western apron or the Executive/Cargo Apron when there is a simultaneous arrival to these aprons as there is only one taxiway available.
+::::
 
 Aircraft from the main apron/terminal shall be pushed onto Z and then via the next appropriate taxiway onto A.
 
 **Example:**
->"GFA512, Taxi to Holding Point A9 Runway 30R via U, Right on A, QNH 1020"
+>"GFA512, taxi to holding point A9 runway 30R via U, right on A."
 
 ### 3.3.2 12L Configuration
-Taxiout from the main apron shall be conducted via Z initially to change to A via S or T as required. Traffic from other aprons conduct their taxiout via A.
+
+Taxi-Out from the main apron shall be conducted via Z initially to change to A via S or T as required. Traffic from other aprons conduct their taxi-out via A.
+
+**Example:**
+>"GFA512, taxi to holding point A1 runway 12L via U, left on A."
 
 ---
 
 ## 3.4 Arrival Taxi Procedure
 ### 3.4.1 General Taxi Procedure
 
-Arriving aircraft shall not immediately be handed off by TWR. They must instead be given an initial taxi instruction onto A to keep traffic flowing. Therefore, SMC shall assign an arrival stand when they are on final approach.
+Arriving aircraft shall not immediately be handed off by TWR. They must instead be given an initial taxi instruction onto A to keep traffic flowing. Therefore, GMC shall assign an arrival stand when they are on final approach.
 
-Once the aircraft is handed off to SMC they may be taxied to their stand.
+Once the aircraft is handed off to GMC, they may be taxied to their stand.
 
 ### 3.4.2 30R Configuration
+
 Aircraft arriving on runway 30R are expected to vacate not before A4. For traffic to aprons other than the main apron, it is recommended to instruct the aircraft to vacate onto A2 to avoid a standoff on taxiway A. Taxiways S or T should be used depending on the traffic situation to cross arrivals on Z so they can enter their assigned stand.
 
 ### 3.4.3 Stand Allocation Procedure
 
-There is no automatic stand assignment available yet for OBBI. For now, SMC shall assign a stand manually via the GRPlugin or the scratchpad. All Commercial airline passenger traffic shall be parked at the new terminal (Stands 12-27).
-
-For Cargo Operators, there is a dedicated cargo apron with stands C1-C5 or on the western apron (50-58)
-
-GA and VIP traffic shall be parked at E1-E4 or 81-88.
+| **Aprons** | **Uses** |
+|:---------------:|:---------------:|
+|       1-6      |    GA Terminal   |
+|       9-28      |    Passenger Terminal   |
+|       C1-C5      |     Cargo Terminal   |
+|  E1-E4 |    Executive Apron  |
+|       50-58      |     Cargo Apron   |
+|       61-63      |     Maintenance   |
+|       70-75      |     Military/Storage   |
+|       81-88      |   GA Apron   |
+|       T1-T4      |   Texel Apron/MENA Aerospace   |
 
 ---
 
@@ -116,6 +133,8 @@ LVO will be enforced when the Runway Visual Range (RVR) reading is 1000m or less
 
 ## 3.6 Designated Areas of Responsibility
 
-Bahrain only has one Ground position. Therefore, the movement areas are only split between SMC and TWR. TWR controls the runway as well as the holding points and exit taxiways. All other movement areas are under the control of SMC.
+Bahrain only has one Ground position. Therefore, the movement areas are only split between GMC and TWR. TWR controls the runway as well as the holding points and exit taxiways. All other movement areas are under the control of GMC.
 
-Handoffs shall be made in such a way that aircraft are not required to stop taxing. Top control is used on VATSIM. When DLV is not online, SMC will assume its reponsibilities.
+Handoffs shall be made in such a way that aircraft are not required to stop taxiing.
+
+VATSIM uses Top-Down control meaning when GMP is offline, GMC will assume its reponsibilities.

--- a/docs/sops/OBBI - Bahrain International Airport/4. Tower.md
+++ b/docs/sops/OBBI - Bahrain International Airport/4. Tower.md
@@ -8,13 +8,13 @@ The section outlines the Standard Operating Procedures for Tower Operations at B
 
 ## 4.1 General Provisions
 
-Tower control (TWR) is responsible for all aerodrome movements on runways and their associated taxiways. TWR shall also ensure separation in the control zone between IFR and IFR traffic is maintained. Traffic information shall also be provided so pilots of VFR traffic can maintain visual separation.
+Tower control (OBBI_TWR) is responsible for all aerodrome movements on runways and their associated taxiways. TWR shall also ensure separation in the control zone between IFR and IFR traffic is maintained. Traffic information shall also be provided so pilots of VFR traffic can maintain visual separation.
 
 ---
 
 ## 4.2 Preferential runway
 
-The preferred calm wind configuration is departing and arriving runway 30R, which shall be used up to a 5-knot tailwind. Otherwise, runway 12L will be used. Tower shall pick the configuration that is used in real life (by checking flight radar) whenever possible.
+The preferred calm wind configuration is departing and arriving runway 30R, which shall be used up to a 5-knot tailwind. Otherwise, runway 12L will be used.
 
 ---
 
@@ -22,38 +22,45 @@ The preferred calm wind configuration is departing and arriving runway 30R, whic
 ### 4.3.1 Standard departure points
 Bahrain features intersections that are allowed as departure points. However, intersection departure points that shall only be assigned after confirmation by the pilot that aircraft performance is sufficient.
 
+|     **Runway 30R**     |   **Runway 12L**  |
+|:---------------------------:|:---------------------:|
+|       **A9**          |       **A1**       |
+|      A8        |       A2        |
+|      A7        |       A3        |
+|      A5        |               |
+
 ### 4.3.2 Line up clerances
 
-Conditional line up instructions shall include the traffic that the aircraft is to follow, as well as the word "BEHIND" at the beginning and end of the transmission. It is recommended to only have a maximum of two conditional line up clerances active at once.
+Conditional line up instructions shall include the traffic that the aircraft is to follow, as well as the word "BEHIND" at the beginning and end of the transmission. It is recommended to only have a maximum of two conditional line up clearances active at once.
 
 **Example:**
->"SWR243, **BEHIND** the Departing OMAN AIR A330, Line up and Wait Runway 30R **BEHIND**."
+>"SWR243, **BEHIND** the Departing Oman Air A330, line up and wait Runway 30R **BEHIND**."
 
-If the aircraft has not yet reached the holding point where they are expected to line up at, ATC shall reiterate the cleared holding point.
+If the aircraft has not yet reached the holding point where they are expected to line up at, TWR shall reiterate the cleared holding point.
 
 **Example:**
->"OMA298, Via A9 Line up and Wait Runway 30R."
+>"OMA298, via A9 line up and wait Runway 30R."
 
 ### 4.3.3 Take-Off Clearances
 
-Aircraft shall be cleared for take-off once adequate separation exists as provided in 4.3.4. In addition, depending on the Bahrain FIR exit point, an initial heading has to be given to the pilot either with or before the takeoff clearance.
+Aircraft shall be cleared for take-off once adequate separation exists as provided in Section 4.3.4. In addition, depending on the Bahrain FIR exit point, an initial heading has to be provided when the aircraft receives their IFR clearance.
 
 **Example:**
->"GFA8KC, After Departure Fly Heading 350, WIND 280 Degrees 4 Knots, Runway 30R, Cleared for Take-Off"
+>"GFA8KC, winds 280 degrees 4 knots, runway 30R, cleared for take-off."
 
 #### Headings 30R Configuration:
 
 | **Exit Route** | **Heading Jet** | **Heading Prop/Helicopter** |
 |:---:|:---:|:---:|
 | B457 NARMI | 300° | 300° |
-| All other routes | 350° | 030° |
+| All other routes | 345° | 030° |
 
 #### Headings 12L Configuration:
 
 | **Exit Route** | **Heading Jet** | **Heading Prop/Helicopter** |
 |:---:|:---:|:---:|
 | N685 TULUB/TOSNA | 120° | 120° |
-| All other routes | 070° | 030° |
+| All other routes | 075° | 030° |
 
 ### 4.3.4 Separation requirements
 #### General
@@ -70,7 +77,7 @@ During low visibilty operations and during IMC in general, departing aircraft sh
 
 ### 4.3.5 IFR handoff procedure
 
-Departing IFR aircraft shall be handed off to the Bahrain TMA controller or when offline to Bahrain Radar instead. Aircraft shall be handed off when passing 800ft to ensure adequate time for a frequency change and avoid a level off on departure.
+Departing IFR aircraft shall be handed off to Bahrain Approach, or when offline, to Bahrain Radar instead. Aircraft shall be handed off when passing **800ft** to ensure adequate time for a frequency change and avoid a level off on departure.
 
 ### 4.3.6 Stopping a departure
 
@@ -79,33 +86,33 @@ Aircraft that have commenced their take-off roll may be instructed to stop immed
 It must be noted though, that the instruction to stop must be given early enough such that the aircraft does not reach its decision speed. The stopping distance of the aircraft is also significant. Therefore, aerodrome controllers must be vigilant and remain aware of the location of traffic at all times as well as runway incursion hotspots.
 
 **Example:**
->"FDB687, Stop immediately, I say again stop immediately, Runway Incursion."
+>"FDB687, stop immediately, I say again stop immediately, runway incursion."
 
-For aircraft that have been given a take-off clearance, but have not yet started the roll , they shall be instructed to hold position and the take-off clearance must be cancelled along with the reason.
+For aircraft that have been given a take-off clearance, but have not yet started the roll, they shall be instructed to hold position and the take-off clearance must be cancelled along with the reason.
 
 **Example:**
->"FDB687, HOLD POSITION, Cancel Take-Off, I say again Cancel Take-Off, Aircraft entering the runway".
+>"FDB687, HOLD POSITION, cancel take-off, I say again cancel take-off, aircraft entering the runway."
 
 ---
 
 ## 4.4 Arrival Procedures
 ### 4.4.1 Preferred exit points
 
-When there are lots of arrival or departure activity, aircraft shall be instructed to vacate at the rapid exit taxiway for the runway in use. Aircraft shall not vacate before A4 in the 30R configuration and not before A6 in the 12L configuration.
+During times of high traffic, aircraft shall be instructed to vacate at the rapid exit taxiway for the runway in use. Aircraft shall not vacate before A4 in the 30R configuration and not before A6 in the 12L configuration.
 
 ::::tip
-In the case of Cargo Aircraft, assigning them a different exit point, such as, A2 in the 30R configuration might be advantageous
+Cargo Aircraft can be assigned a different exit point such as A2 in the 30R configuration.
 ::::
 
 ### 4.4.2 Separation Requirements
 #### General
-While the radar controllers are responsible for separating arriving aircraft, the TWR controller shall still ensure that minimum separation (>3nm) is maintained until the preceding aircraft crosses the runway threshold.
+Although radar controllers are responsible for separating arriving aircraft, the TWR controller shall still ensure that minimum separation (>3nm) is maintained until the preceding aircraft crosses the runway threshold.
 
 #### Speed control
 If it is apparent that minimum separation may not exist, TWR may use a tactical reduction in aircraft speed.
 
 **Example:**
->"OMA1784, Reduce to Final Approach Speed".
+>"OMA1784, Reduce to Final Approach Speed."
 
 #### Visual Separation 
 Aircraft may be instructed to maintain own separation visually, if speed control alone will not resolve the conflict. This shall only be done in VMC and in agreement with the pilot. If no other solutions are practical, the succeeding aircraft shall be instructed to go around.
@@ -115,20 +122,20 @@ Aircraft may be instructed to maintain own separation visually, if speed control
 At any time should a runway become unsuitable for an aircraft landing, or separation minima is not met, aircraft shall be instructed to go-around. Published Go-Around Procedure at Bahrain is to Fly Runway heading and climb to 2500ft.
 
 **Example:**
->"UAE175, Go Around, I say again, Go Around, Acknowledge".
+>"UAE175, go around, I say again, go around, acknowledge."
 
-Once the aircraft has acknowledged the instruction and is observed to be safely climbing away, they shall be handed off to Bahrain TMA.
+Once the aircraft has acknowledged the instruction and is observed to be safely climbing away, they shall be handed off to Bahrain Approach.
 
 **Example:**
->"UAE175, Standard Missed Approach Procedure, Contact Bahrain Approach 127.85".
+>"UAE175, standard missed approach procedure, contact Bahrain Approach 127.850."
 
 ### 4.4.4 Arrival Taxi Procedure
 
-In accordance with the taxi procedure laid down in 3.4, aircraft shall be provided an initial taxi clearance to ensure they are kept moving such that the rapid exit taxiway (RET) is clear for the next arrival.
+In accordance with the taxi procedure laid down in Section 3.4, aircraft shall be provided an initial taxi clearance to ensure they are kept moving such that the rapid exit taxiway (RET) is clear for the next arrival.
 
 The inital taxi shall include instructions to taxi "LEFT" or "RIGHT" onto the relevant taxiway as appropriate and hold at a suitable location.
 
 **Example:**
->"OMA8KC, Taxi LEFT on A, HOLD SHORT of R".
+>"OMA8KC, taxi LEFT on A, HOLD SHORT of R".
 
-Once the aircraft has been observed to be taxiing and completely clear of the RET, transfer of control shall be initiated to SMC provided there will be no conflicts with other traffic.
+Once the aircraft has been observed to be taxiing and completely clear of the RET, transfer of control shall be initiated to GMC provided there will be no conflicts with other traffic.


### PR DESCRIPTION
-Fixed typos
------
- Delivery provides heading to fly after departure in the clearance
- Delivery hands off tfc to ground after reading back clearance correctly

- Ground gives QNH on pushback, not taxi.

- Tower does not give heading in take off clearance anymore.